### PR TITLE
Website changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,9 @@
+Assembly Terms of Service
+=========================
+
+This repository keeps a publically available history of all our policies.
+It designed for historical change tracking and not the recommended way for end users to browse our documentation.
+
+If you wish to explore our policies we recommend you view them on our website instead.
+
+## [Browse our Terms & Conditions here...](https://assembly.education/terms)

--- a/README.md
+++ b/README.md
@@ -6,4 +6,4 @@ It designed for historical change tracking and not the recommended way for end u
 
 If you wish to explore our policies we recommend you view them on our website instead.
 
-## [Browse our Terms & Conditions here...](https://assembly.education/terms)
+## [Browse our Terms & Conditions here...](http://assembly.education/terms)

--- a/developer-agreement.md
+++ b/developer-agreement.md
@@ -1,10 +1,8 @@
-![Assembly Education: Terms of Service](http://assembly.education/images/assembly-logo-afe63f47.png)
-
 ### Third Party Developer Agreement
 
 Assembly is committed to raising the standards of privacy and security applied to the management of education data.  In order to do this, we expect all Third Party Developers who connect to, or wish to connect to, the Assembly platform to sign and accept our Third Party Developer Agreement and comply with it at all times.
 
-While this is an important and legally-binding document, we’ve tried to keep this agreement as readable and user-friendly as possible. We have, however, stuck to some conventional legal document practices (such as capitalisation of ‘You’ and ‘Us’ in relation to each party) where it’s helpful for clarity. 
+While this is an important and legally-binding document, we’ve tried to keep this agreement as readable and user-friendly as possible. We have, however, stuck to some conventional legal document practices (such as capitalisation of ‘You’ and ‘Us’ in relation to each party) where it’s helpful for clarity.
 ## Who do these terms apply to?
 This agreement is between You, a Third Party Developer and Assembly Partner, and Assembly.  If you do not, or cannot, agree to these terms you should not use the Assembly platform.
 ## Our commitment to You
@@ -48,7 +46,7 @@ Use the school data made available via the Assembly platform for the purposes of
 
 **As a Third Party Developer you agree to:**
 
-* Pass data back to the Assembly Platform using using modern and best practice encryption technologies. 
+* Pass data back to the Assembly Platform using using modern and best practice encryption technologies.
 * Provide Assembly with links to your Terms of Service and Privacy Policy, and notify Assembly of changes you intend to make to these documents before they are made active
 * Ensure that your Assembly account details are kept secure at all times
 
@@ -59,15 +57,15 @@ Use the school data made available via the Assembly platform for the purposes of
 If You do not comply with any part of this agreement, Assembly reserve the right to suspend or terminate Your access to the Assembly platform with immediate effect.
 
 If Assembly terminate Your access to the Assembly platform due to breach of this agreement, You agree to delete all data provided to You through the Assembly platform within three working days.
-Assembly reserve all rights in our intellectual property and You may not use our intellectual property (code, trademarks or other material) without Our consent. 
+Assembly reserve all rights in our intellectual property and You may not use our intellectual property (code, trademarks or other material) without Our consent.
 
 **Assembly and You both agree:**
 
 * that no failure or delay to exercise any right or remedy under this agreement or by law shall constitute a waiver of that right or any other right or remedy.
 
-* that if any part of this agreement becomes invalid it will be modified to the minimum extent necessary to make it valid. If Assembly cannot agree this with you, the relevant provision shall be deleted. Any modification to or deletion of a provision shall not affect the validity of the rest of the agreement. 
+* that if any part of this agreement becomes invalid it will be modified to the minimum extent necessary to make it valid. If Assembly cannot agree this with you, the relevant provision shall be deleted. Any modification to or deletion of a provision shall not affect the validity of the rest of the agreement.
 
-* that any dispute or claim arising out of or relating to this agreement that cannot be resolved by negotiation within 14 days shall be resolved through arbitration. Either party shall give notice of seeking a resolution through arbitration using the CEDR procedure and English law. Either party may seek an interim remedy in court if necessary. 
+* that any dispute or claim arising out of or relating to this agreement that cannot be resolved by negotiation within 14 days shall be resolved through arbitration. Either party shall give notice of seeking a resolution through arbitration using the CEDR procedure and English law. Either party may seek an interim remedy in court if necessary.
 
 * that any dispute or claim arising out of or relating to this agreement shall be governed by the law of England and that the courts of England shall have exclusive jurisdiction provided that Assembly can take action in other places if You are in breach of this agreement.
 
@@ -77,4 +75,4 @@ You accept that you will maintain and support any applications You develop which
 
 You accept that Assembly is provided to You on an “as is” and “as available” basis.  The Assembly platform is provided to You without guarantees or warranties.  Assembly makes no guarantee that the website, the platform or any of our tools are error free or that access will be continuous or uninterrupted.
 
-Assembly shall not, under any circumstances, be liable to You, whether in contract, tort (including negligence), breach of statutory duty, or otherwise, arising under or in connection with this agreement for: loss of profits, sales, business, or revenue (direct or indirect); business interruption; loss of anticipated savings; loss or corruption of data or information; loss of business opportunity, goodwill or reputation; or, any indirect or consequential loss or damage. Assembly are not excluding liability for death or personal injury caused by negligence, breach of any implied term and any other matter for which it would unlawful to exclude liability. 
+Assembly shall not, under any circumstances, be liable to You, whether in contract, tort (including negligence), breach of statutory duty, or otherwise, arising under or in connection with this agreement for: loss of profits, sales, business, or revenue (direct or indirect); business interruption; loss of anticipated savings; loss or corruption of data or information; loss of business opportunity, goodwill or reputation; or, any indirect or consequential loss or damage. Assembly are not excluding liability for death or personal injury caused by negligence, breach of any implied term and any other matter for which it would unlawful to exclude liability.

--- a/glossary.md
+++ b/glossary.md
@@ -1,5 +1,3 @@
-![Assembly Education: Terms of Service](http://assembly.education/images/assembly-logo-afe63f47.png)
-
 ### Glossary of Terms
 
 __This document defines the terms we use throughout our [Terms and Conditions](https://assembly.education/terms), [Privacy Statement](https://assembly.education/privacy) and other Assembly documents:__

--- a/glossary.md
+++ b/glossary.md
@@ -2,7 +2,7 @@
 
 ### Glossary of Terms
 
-__This document defines the terms we use throughout our [Terms and Conditions](https://github.com/assembly-edu/terms-of-service/blob/master/terms.md), [Privacy Statement](https://github.com/assembly-edu/terms-of-service/blob/master/privacy-statement.md) and other Assembly documents:__
+__This document defines the terms we use throughout our [Terms and Conditions](https://assembly.education/terms), [Privacy Statement](https://assembly.education/privacy) and other Assembly documents:__
 
 __Data Controller:__ the person, or organisation, who determines the purposes for which and the manner in which any personal data is processed.  With respect to the Assembly Platform the Data Controller is the School who connects to the Assembly Platform.
 
@@ -18,7 +18,7 @@ __Assembly Connector:__ The program that schools must install, to connect their 
 
 __Assembly Applications:__ Applications built by Third Parties which connect to the Assembly Platform.  Some Assembly Applications may be built by Assembly.
 
-__Developer Agreement:__ A [pledge](https://github.com/assembly-edu/terms-of-service/blob/master/developer-agreement.md) that we ask all third party developers to sign up to in order to integrate with the Assembly Platform.
+__Developer Agreement:__ A [pledge](https://assembly.education/developer-agreement) that we ask all third party developers to sign up to in order to integrate with the Assembly Platform.
 
 __IP Address:__ A unique computer address that identifies you to the Internet, or your local network.
 

--- a/glossary.md
+++ b/glossary.md
@@ -1,6 +1,6 @@
 ### Glossary of Terms
 
-__This document defines the terms we use throughout our [Terms and Conditions](https://assembly.education/terms), [Privacy Statement](https://assembly.education/privacy) and other Assembly documents:__
+__This document defines the terms we use throughout our [Terms and Conditions](http://assembly.education/terms), [Privacy Statement](http://assembly.education/privacy) and other Assembly documents:__
 
 __Data Controller:__ the person, or organisation, who determines the purposes for which and the manner in which any personal data is processed.  With respect to the Assembly Platform the Data Controller is the School who connects to the Assembly Platform.
 
@@ -16,7 +16,7 @@ __Assembly Connector:__ The program that schools must install, to connect their 
 
 __Assembly Applications:__ Applications built by Third Parties which connect to the Assembly Platform.  Some Assembly Applications may be built by Assembly.
 
-__Developer Agreement:__ A [pledge](https://assembly.education/developer-agreement) that we ask all third party developers to sign up to in order to integrate with the Assembly Platform.
+__Developer Agreement:__ A [pledge](http://assembly.education/developer-agreement) that we ask all third party developers to sign up to in order to integrate with the Assembly Platform.
 
 __IP Address:__ A unique computer address that identifies you to the Internet, or your local network.
 

--- a/privacy-statement.md
+++ b/privacy-statement.md
@@ -4,7 +4,7 @@
 
 This statement underpins the policies, promises and contracts we make with schools relating to the education data that Assembly processes.
 
-In conjunction with this document, you should read the [Glossary of Terms](https://github.com/assembly-edu/terms-of-service/blob/master/glossary.md) used within this statement, and also elsewhere on our site.
+In conjunction with this document, you should read the [Glossary of Terms](https://assembly.education/privacy/glossary) used within this statement, and also elsewhere on our site.
 
 ### What is Assembly?
 
@@ -14,9 +14,9 @@ Assembly is a secure, cloud-based platform that connects to your school’s Mana
 
 __1. Introduction__
 
-Privacy and security are at the heart of everything we do at Assembly. This statement explains the key measures we’ve put in place to ensure that a school’s data is kept secure and processed appropriately at all times. It also covers our commitments to you, and what we expect from schools in terms of privacy and data protection. 
+Privacy and security are at the heart of everything we do at Assembly. This statement explains the key measures we’ve put in place to ensure that a school’s data is kept secure and processed appropriately at all times. It also covers our commitments to you, and what we expect from schools in terms of privacy and data protection.
 
-For further detail, please refer to our full [Platform Terms of Service](https://github.com/assembly-edu/terms-of-service/blob/master/terms.md), which provide a full explanation of how we process and protect data as well as what we require from schools to agree to before deciding to use our service.
+For further detail, please refer to our full [Platform Terms of Service](https://assembly.education/terms), which provide a full explanation of how we process and protect data as well as what we require from schools to agree to before deciding to use our service.
 
 __2. Our Principles__
 
@@ -28,13 +28,13 @@ __We:__
 * Transport and store all personal data originating from schools using modern and best practice encryption technologies.  This includes Secure Socket Layers (SSL/TLS) for encrypted data transfer over the internet, encryption of all data at rest, field-level encryption for personally identifiable data and password-protected identities for all end users
 * Comply with all Subject Access Requests made relating to the data We store
 * Only retain data for as long as required, and delete all your data if you ask us to do so, if you delete the connector or if your account becomes inactive.
-* Ensure that all data is held securely by taking steps so that data is not corrupted or lost 
+* Ensure that all data is held securely by taking steps so that data is not corrupted or lost
 * Ensure that all staff having access to personal data hold a valid Disclosure and Barring Service certificate
 * Always maintain adequate liability insurance
 * Audit our services against this pledge every 12 months and provide evidence of compliance to the other party whenever requested
-* Report any breaches of security to the tata controller, the Information Commissioner’s Office (ICO) and other authorities if required by law, and, in co-operation with the data controller, to data subjects 
+* Report any breaches of security to the tata controller, the Information Commissioner’s Office (ICO) and other authorities if required by law, and, in co-operation with the data controller, to data subjects
 * Always notify schools prior to connecting an Assembly application which data that  Assembly application needs access to, and allow you to accept or reject that request
-* Make the [Terms of Service](https://github.com/assembly-edu/terms-of-service/blob/master/terms.md) and this Privacy Policy clearly and publicly available on our website
+* Make the [Terms of Service](https://assembly.education/terms) and this Privacy Policy clearly and publicly available on our website
 
 __We DO NOT:__
 
@@ -52,7 +52,7 @@ We take every reasonable measure to ensure we store data securely. The Assembly 
 
 * All personal and sensitive Assembly data is stored and transported within EU or countries which are granted to have [Adequate Levels of Protection](http://ec.europa.eu/justice/data-protection/international-transfers/adequacy/index_en.htm) as defined by the European Commission
 * All external data transmissions to and from the Assembly Platform are encrypted using modern SSL/TLS protocols and ciphers
-* Encryption at rest i.e. when stored on a disk or laptop 
+* Encryption at rest i.e. when stored on a disk or laptop
 * Field level encryption in our database, where we feel it necessary to do so
 * We use encrypted passwords with variable permissions according to the user’s role are used for access to all sensitive information
 * All servers are situated in secure locations that comply with the Data Protection Act 1998
@@ -69,7 +69,7 @@ We retain personal data on our platform for as long as necessary to provide the 
 
 __6. Assembly and Third Party applications__
 
-We ask all Third Party Application Developers to sign up to our [Third Party Developer Agreement.](https://github.com/assembly-edu/terms-of-service/blob/master/developer-agreement.md)  
+We ask all Third Party Application Developers to sign up to our [Third Party Developer Agreement.](https://assembly.education/developer-agreement)
 
 Schools are responsible for accepting the terms and conditions of third party applications. We make these clearly available through the Assembly platform.
 
@@ -80,7 +80,7 @@ __7. Privacy or Security Breaches__
 We take all reasonable and necessary precautions to ensure that your data is secure and to recognise and then mitigate the risks to security and privacy.  However, it is not possible to 100% guarantee the security of any data transmitted or stored electronically.  In the event that a breach of security or privacy did occur, Assembly will contact Data Controller of the affected data, and inform the Information Commissioner’s Office (ICO), and other authorities, if required by law.
 
 
-### Information for students and parents 
+### Information for students and parents
 
 Assembly, as the Data Processor, only has access to pupil data as requested by the school, as Data Controller, and only for the purposes of performing services on a school’s behalf.
 
@@ -98,9 +98,9 @@ If you are a registered user of the Assembly website, or have expressed interest
 
 __10. Third Party Websites__
 
-We cannot be responsible for the privacy policies and practices of other sites even if you access them using links on our website. We recommend that you check the policy of each site you visit and contact the owner or operator if you have any questions or concerns. 
+We cannot be responsible for the privacy policies and practices of other sites even if you access them using links on our website. We recommend that you check the policy of each site you visit and contact the owner or operator if you have any questions or concerns.
 
-If you access our Website from a third party site, we cannot be responsible for the privacy policy and practice of that third party site and recommend that you check the policy of that third party site and contact the owner or operator if you have any questions or concerns.  
+If you access our Website from a third party site, we cannot be responsible for the privacy policy and practice of that third party site and recommend that you check the policy of that third party site and contact the owner or operator if you have any questions or concerns.
 
 ### Questions
 If you have any questions or grievances in relation to security or privacy, please email us on <hello@assembly.education>

--- a/privacy-statement.md
+++ b/privacy-statement.md
@@ -1,5 +1,3 @@
-![Assembly Education: Terms of Service](http://assembly.education/images/assembly-logo-afe63f47.png)
-
 # Privacy Statement
 
 This statement underpins the policies, promises and contracts we make with schools relating to the education data that Assembly processes.

--- a/privacy-statement.md
+++ b/privacy-statement.md
@@ -2,7 +2,7 @@
 
 This statement underpins the policies, promises and contracts we make with schools relating to the education data that Assembly processes.
 
-In conjunction with this document, you should read the [Glossary of Terms](https://assembly.education/privacy/glossary) used within this statement, and also elsewhere on our site.
+In conjunction with this document, you should read the [Glossary of Terms](http://assembly.education/privacy/glossary) used within this statement, and also elsewhere on our site.
 
 ### What is Assembly?
 
@@ -14,7 +14,7 @@ __1. Introduction__
 
 Privacy and security are at the heart of everything we do at Assembly. This statement explains the key measures we’ve put in place to ensure that a school’s data is kept secure and processed appropriately at all times. It also covers our commitments to you, and what we expect from schools in terms of privacy and data protection.
 
-For further detail, please refer to our full [Platform Terms of Service](https://assembly.education/terms), which provide a full explanation of how we process and protect data as well as what we require from schools to agree to before deciding to use our service.
+For further detail, please refer to our full [Platform Terms of Service](http://assembly.education/terms), which provide a full explanation of how we process and protect data as well as what we require from schools to agree to before deciding to use our service.
 
 __2. Our Principles__
 
@@ -32,7 +32,7 @@ __We:__
 * Audit our services against this pledge every 12 months and provide evidence of compliance to the other party whenever requested
 * Report any breaches of security to the tata controller, the Information Commissioner’s Office (ICO) and other authorities if required by law, and, in co-operation with the data controller, to data subjects
 * Always notify schools prior to connecting an Assembly application which data that  Assembly application needs access to, and allow you to accept or reject that request
-* Make the [Terms of Service](https://assembly.education/terms) and this Privacy Policy clearly and publicly available on our website
+* Make the [Terms of Service](http://assembly.education/terms) and this Privacy Policy clearly and publicly available on our website
 
 __We DO NOT:__
 
@@ -67,7 +67,7 @@ We retain personal data on our platform for as long as necessary to provide the 
 
 __6. Assembly and Third Party applications__
 
-We ask all Third Party Application Developers to sign up to our [Third Party Developer Agreement.](https://assembly.education/developer-agreement)
+We ask all Third Party Application Developers to sign up to our [Third Party Developer Agreement.](http://assembly.education/developer-agreement)
 
 Schools are responsible for accepting the terms and conditions of third party applications. We make these clearly available through the Assembly platform.
 

--- a/terms.md
+++ b/terms.md
@@ -1,9 +1,9 @@
-﻿##Terms of Service
+﻿# Terms of Service
 
 Please read these Terms of Service carefully and in full before using any of our services.  If you do not agree to these Terms of Service, you should not use the Assembly Platform.
 While this is an important and legally-binding document, we’ve tried to keep these Terms of Service as readable and user-friendly as possible. We have, however, stuck to some conventional legal document practices (such as capitalisation of ‘You’ and ‘Us’ in relation to each party) where it’s helpful for clarity.
 
-###Glossary
+## Glossary
 
 __Data Controller:__ The person, or organisation, who determines the purposes for which and the manner in which any personal data is processed.  With respect to the Assembly Platform the Data Controller is the School who connects to the Assembly Platform.
 
@@ -24,12 +24,12 @@ __Third Party Developer Agreement:__ A pledge that we ask all third party develo
 __IP Address:__ A unique computer address that identifies you to the Internet, or your local network.
 
 
-###What is Assembly?
+## What is Assembly?
 
 Assembly is a secure, cloud-based Platform that connects to your school’s Management Information System (MIS), extracts key elements of your school’s data, and stores it in a way that allows you to connect other applications to your data. These applications allow you to extend, analyse and aggregate data you collect and store in school.
 These Terms of Service explain how we process your data, how we protect your data, and what we expect from you when you use our Platform.
 
-###Who do these terms apply to?
+## Who do these terms apply to?
 
 These Terms of Service are between You, a school, and Us, Assembly. These terms do not apply to third parties such as developers, pupils or parents.
 Whilst using the Assembly Platform You will send data to Us about Your school for Us to process on Your behalf. As a school, You are the Data Controller and Assembly is the Data Processor, and You will remain Data Controller at all times.  As a Data Controller it is therefore Your responsibility to ensure that You are able to engage with Assembly on these terms , and are able to allow us to process the data you control on behalf of Your Data Subjects.  You must not connect to the platform if You do not agree with these Terms of Service.
@@ -37,11 +37,12 @@ These Terms of Service apply only to the Assembly Connector and the Assembly Pla
 
 Assembly Applications, whether created by Assembly or a Third Party, are subject to their own Terms and Conditions and Policies.  Before You connect Assembly Applications to the Assembly Platform You must also ensure that You read, and agree to, such Assembly Application’s individual Terms and Conditions and Policies.
 
-##Summary Terms of Service
+## Summary Terms of Service
 
 __Here’s a brief summary of the things that we think are particularly important, both in terms of Our key commitments to You and Your responsibilities as a platform user:__
 
-__You agree to:__
+#### You agree to:
+
 * Only connect to the Assembly platform with the authorisation of the person with data protection responsibilities within your school (a role commonly referred to as ‘data protection lead’, likely to be the head teacher or a senior leader)
 
 * Retain Your responsibility as the Data Controller, and comply with the legal responsibilities it brings, over the data held within the platform, including its accuracy and completeness
@@ -49,14 +50,14 @@ __You agree to:__
 * Only connect to the platform if You are able to do so in accordance with the Data Protection Act
 * Have full responsibility for who you choose to share your data with, and not to connect to any third party applications unless satisfied with their terms and conditions, and the privacy policies which govern them
 
-__You agree not to:__
+#### You agree not to:
 
 * Copy or share any of Our tools or content
 * Use Our Intellectual Property (code, trademarks or other material) without Our consent
 * Do anything which adversely affects the security of the Platform, for example infecting it with viruses, Trojan horses or other similar harmful components that could affect or delay delivery of our services
 * Access, attempt to access, or inspect any data for which you do not have permission
 
-__We agree to:__
+#### We agree to:
 
 * Process the data received from You for the purposes of education and school improvement only, and only for those purposes necessary to provide the service explicitly offered to You
 * Adhere strictly to the terms of the Data Protection Act 1998 and any future amendments or applicable legislation
@@ -73,7 +74,7 @@ __We agree to:__
 * Always notify You prior to connecting an Assembly Application which data that  Assembly Application needs access to, and allow You to accept or reject that request
 * Make Terms of Service and Privacy Policies clearly and publicly available on our websites
 
-__We agree not to:__
+#### We agree not to:
 
 * Store or transport personal or sensitive data outside of the EEA or outside of countries which are granted to have Adequate Levels of Protection as defined by the European Commission
 * Share your data with any third parties except where explicitly requested by you or required by law.
@@ -83,10 +84,12 @@ __We agree not to:__
 * Share information with other third parties except where specifically agreed by the Data Controller or where required by law
 * Change any applicable terms of service without giving You the opportunity to opt-out of such changes
 
-##Detailed Terms of Service
+## Detailed Terms of Service
 
 Now, here’s a bit more detail on Our full terms in each area:
-__*#Restrictions and Responsibilities#*__
+
+#### Restrictions and Responsibilities
+
 __1. Connecting your MIS to the Platform:__ In order to use Our service, You will be providing access to information about Your school through Your Management Information System (MIS). It is Your responsibility to connect to the Platform in a properly authorised way. Assembly has access to Your school data only as requested by You, and only for the purposes of performing services on Your behalf.
 
 __2. Usage:__ Assembly exists to assist You in extending, analysing and aggregating Your data for the purposes of school improvement. You agree to use Our services for this purpose only.
@@ -109,7 +112,7 @@ __10. Third Party Assembly Applications:__  The Assembly Platform allows You to 
 
 __11. Termination:__  We will suspend or restrict Your access to Our services if We have reason to believe You may have breached the conditions of this agreement.
 
-##Security and Privacy
+#### Security and Privacy
 
 Your privacy is our top priority, and We will not use Your data for anything other than what is set out in this agreement.
 
@@ -137,21 +140,21 @@ __11. Communication:__  If you are a registered user of the Assembly website, or
 
 __12. Privacy or Security Breaches:__  We take all reasonable, necessary precautions to ensure that your data is secure and to recognise and then mitigate the risks to security and privacy.  However, it is not possible to 100% guarantee the security of any data transmitted or stored electronically.  In the event that a breach of security or privacy did occur, Assembly will contact the Data Controller, and inform the Information Commissioner’s Office (ICO) and other authorities if required by law.
 
-##Questions and Grievances
+## Questions and Grievances
 
 If you have any questions or grievances in relation to security or privacy, please email us on help@assembly.education.
 
-##Information for students and parents
+## Information for students and parents
 
 Assembly as the Data Processor only has access to pupil data as requested by the school as Data Controller and only for the purposes of performing services on a school’s behalf.
 Your child’s school remains the Data Controller of any pupil data we process. If you have questions about your or your child’s data or how your school is making use of services like Assembly, please contact the school directly.  Any pupil or parent/guardian enquiries we receive will be directed to the relevant school as the Data Controller for that child’s or parent’s/guardian’s data.
 
-##Changes to the Terms of Service
+## Changes to the Terms of Service
 
 We are constantly updating and expanding our services. This means that sometimes we have to add to or modify the terms under which we offer our services.  If we make material changes, we will let you know via email before these changes take effect. We also keep a log of material changes at the bottom of this page. The email will designate a reasonable period of time after which the new terms will take effect.
 If you disagree with the changes then you must discontinue your use of our service. Continuing to use our services constitutes agreement to the new terms, and your continued use will be subject to these terms.
 
-##General
+## General
 
 If You do not comply with any part of this agreement, We reserve the right to suspend or terminate Your access to the Assembly platform with immediate effect.
 

--- a/terms.md
+++ b/terms.md
@@ -1,9 +1,7 @@
-﻿![Assembly Education: Terms of Service](http://assembly.education/images/assembly-logo-afe63f47.png)
-
-##Terms of Service
+﻿##Terms of Service
 
 Please read these Terms of Service carefully and in full before using any of our services.  If you do not agree to these Terms of Service, you should not use the Assembly Platform.
-While this is an important and legally-binding document, we’ve tried to keep these Terms of Service as readable and user-friendly as possible. We have, however, stuck to some conventional legal document practices (such as capitalisation of ‘You’ and ‘Us’ in relation to each party) where it’s helpful for clarity. 
+While this is an important and legally-binding document, we’ve tried to keep these Terms of Service as readable and user-friendly as possible. We have, however, stuck to some conventional legal document practices (such as capitalisation of ‘You’ and ‘Us’ in relation to each party) where it’s helpful for clarity.
 
 ###Glossary
 
@@ -28,7 +26,7 @@ __IP Address:__ A unique computer address that identifies you to the Internet, o
 
 ###What is Assembly?
 
-Assembly is a secure, cloud-based Platform that connects to your school’s Management Information System (MIS), extracts key elements of your school’s data, and stores it in a way that allows you to connect other applications to your data. These applications allow you to extend, analyse and aggregate data you collect and store in school.  
+Assembly is a secure, cloud-based Platform that connects to your school’s Management Information System (MIS), extracts key elements of your school’s data, and stores it in a way that allows you to connect other applications to your data. These applications allow you to extend, analyse and aggregate data you collect and store in school.
 These Terms of Service explain how we process your data, how we protect your data, and what we expect from you when you use our Platform.
 
 ###Who do these terms apply to?
@@ -71,7 +69,7 @@ __We agree to:__
 * Ensure that all staff having access to personal data hold a valid Disclosure and Barring Service certificate
 * Always maintain adequate liability insurance
 * Audit our services against this pledge every 12 months and provide evidence of compliance to the other party whenever requested
-* Report any breaches of security to The Data Controller, the Information Commissioner’s Office (ICO) and other authorities if required by law, and, in co-operation with the Data Controller, to Data Subjects 
+* Report any breaches of security to The Data Controller, the Information Commissioner’s Office (ICO) and other authorities if required by law, and, in co-operation with the Data Controller, to Data Subjects
 * Always notify You prior to connecting an Assembly Application which data that  Assembly Application needs access to, and allow You to accept or reject that request
 * Make Terms of Service and Privacy Policies clearly and publicly available on our websites
 
@@ -105,17 +103,17 @@ __7. Payment:__  Assembly offers a combination of free and paid‐for services. 
 
 __8. Disclaimer of Warranties:__  You accept that tools are provided on an “as is” and “as available” basis. They are provided without guarantees or warranties. Assembly makes no guarantee that the website or any of the tools are error free or that access will be continuous and uninterrupted.
 
-__9. Liability:__  We shall not, under any circumstances, be liable to You, whether in contract, tort (including negligence), breach of statutory duty, or otherwise, arising under or in connection with this agreement for: loss of profits, sales, business, or revenue (direct or indirect); business interruption; loss of anticipated savings; loss or corruption of data or information; loss of business opportunity, goodwill or reputation; or, any indirect or consequential loss or damage. We are not excluding liability for death or personal injury caused by negligence, breach of any implied term and any other matter for which it would unlawful to exclude liability. 
+__9. Liability:__  We shall not, under any circumstances, be liable to You, whether in contract, tort (including negligence), breach of statutory duty, or otherwise, arising under or in connection with this agreement for: loss of profits, sales, business, or revenue (direct or indirect); business interruption; loss of anticipated savings; loss or corruption of data or information; loss of business opportunity, goodwill or reputation; or, any indirect or consequential loss or damage. We are not excluding liability for death or personal injury caused by negligence, breach of any implied term and any other matter for which it would unlawful to exclude liability.
 
-__10. Third Party Assembly Applications:__  The Assembly Platform allows You to connect Your data to Third Parties. We have strict privacy and security criteria and require all Third Party Application Developers to sign up to our Third Party Developer Agreement.  As the Data Controller You are responsible for ensuring that You understand and agree to the terms of any Third Party Applications.  These Third Party Application terms will be made available to You via the Assembly Platform.  Whilst We aim to ensure strict standards of security and privacy within Third Party Applications, We are not liable for any Third Party Applications. We also accept no responsibility for any sums payable by You to any Third Party Application providers. 
+__10. Third Party Assembly Applications:__  The Assembly Platform allows You to connect Your data to Third Parties. We have strict privacy and security criteria and require all Third Party Application Developers to sign up to our Third Party Developer Agreement.  As the Data Controller You are responsible for ensuring that You understand and agree to the terms of any Third Party Applications.  These Third Party Application terms will be made available to You via the Assembly Platform.  Whilst We aim to ensure strict standards of security and privacy within Third Party Applications, We are not liable for any Third Party Applications. We also accept no responsibility for any sums payable by You to any Third Party Application providers.
 
 __11. Termination:__  We will suspend or restrict Your access to Our services if We have reason to believe You may have breached the conditions of this agreement.
 
 ##Security and Privacy
 
-Your privacy is our top priority, and We will not use Your data for anything other than what is set out in this agreement. 
+Your privacy is our top priority, and We will not use Your data for anything other than what is set out in this agreement.
 
-__1. Data Storage and Access:__  All personal and sensitive Assembly data is stored and transported within EEA or countries which are granted to have Adequate Levels of Protection as defined by the European Commission.  Internal access to information is limited to only those who require it to perform their jobs.  Other security safeguards include firewalls and physical building access controls.  We use role-based identities and password protection on all platform services and apps. 
+__1. Data Storage and Access:__  All personal and sensitive Assembly data is stored and transported within EEA or countries which are granted to have Adequate Levels of Protection as defined by the European Commission.  Internal access to information is limited to only those who require it to perform their jobs.  Other security safeguards include firewalls and physical building access controls.  We use role-based identities and password protection on all platform services and apps.
 
 __2. Security and Encryption:__  We have invested heavily in security and we use a suite of modern encryption methods to secure the data held within the Assembly Platform.  All our data is encrypted at rest.  We use additional field level encryption within the platform where We deem it necessary to protect the integrity of the data We store (for example, UPN).  All external data transmissions to and from the Assembly Platform are encrypted using modern SSL/TLS protocols and ciphers.  We capture IP addresses to ensure that our service is secure, for example from denial of service attacks.
 
@@ -145,25 +143,25 @@ If you have any questions or grievances in relation to security or privacy, plea
 
 ##Information for students and parents
 
-Assembly as the Data Processor only has access to pupil data as requested by the school as Data Controller and only for the purposes of performing services on a school’s behalf. 
+Assembly as the Data Processor only has access to pupil data as requested by the school as Data Controller and only for the purposes of performing services on a school’s behalf.
 Your child’s school remains the Data Controller of any pupil data we process. If you have questions about your or your child’s data or how your school is making use of services like Assembly, please contact the school directly.  Any pupil or parent/guardian enquiries we receive will be directed to the relevant school as the Data Controller for that child’s or parent’s/guardian’s data.
 
 ##Changes to the Terms of Service
 
-We are constantly updating and expanding our services. This means that sometimes we have to add to or modify the terms under which we offer our services.  If we make material changes, we will let you know via email before these changes take effect. We also keep a log of material changes at the bottom of this page. The email will designate a reasonable period of time after which the new terms will take effect. 
+We are constantly updating and expanding our services. This means that sometimes we have to add to or modify the terms under which we offer our services.  If we make material changes, we will let you know via email before these changes take effect. We also keep a log of material changes at the bottom of this page. The email will designate a reasonable period of time after which the new terms will take effect.
 If you disagree with the changes then you must discontinue your use of our service. Continuing to use our services constitutes agreement to the new terms, and your continued use will be subject to these terms.
 
 ##General
 
 If You do not comply with any part of this agreement, We reserve the right to suspend or terminate Your access to the Assembly platform with immediate effect.
 
-We and You both agree: 
+We and You both agree:
 
 * that no failure or delay to exercise any right or remedy under this agreement or by law shall constitute a waiver of that right or any other right or remedy.
 
-* that if any part of this agreement becomes invalid it will be modified to the minimum extent necessary to make it valid. If we cannot agree this with you, the relevant provision shall be deleted. Any modification to or deletion of a provision shall not affect the validity of the rest of the agreement. 
+* that if any part of this agreement becomes invalid it will be modified to the minimum extent necessary to make it valid. If we cannot agree this with you, the relevant provision shall be deleted. Any modification to or deletion of a provision shall not affect the validity of the rest of the agreement.
 
-* that any dispute or claim arising out of or relating to this agreement that cannot be resolved by negotiation within 14 days shall be resolved through arbitration. Either party shall give notice of seeking a resolution through arbitration using the CEDR procedure and English law. Either party may seek an interim remedy in court if necessary. 
+* that any dispute or claim arising out of or relating to this agreement that cannot be resolved by negotiation within 14 days shall be resolved through arbitration. Either party shall give notice of seeking a resolution through arbitration using the CEDR procedure and English law. Either party may seek an interim remedy in court if necessary.
 
 * that any dispute or claim arising out of or relating to this agreement shall be governed by the law of England and that the courts of England shall have exclusive jurisdiction provided that we can take action in other places if You are in breach of this agreement.
 


### PR DESCRIPTION
Formatting changes to better support documentation being shown in the context of the Assembly website.

This contains no material changes to the terms but it does...

- remove the header image
- tidy markdown headings to all be the same format
- make all links refer to http://assembly.education over github
- add a README to people landing on github have some context of where they can view the documents.